### PR TITLE
Updates related to generating remaining historical forcing

### DIFF
--- a/example_usage/README.md
+++ b/example_usage/README.md
@@ -20,7 +20,8 @@ conda create -n ismip6_ocean_forcing -c conda-forge python=3.6 numpy scipy \
 conda activate ismip6_ocean_forcing
 ```
 
-2. Clone the https://github.com/xylar/ismip6-ocean-forcing repo somewhere
+2. Clone the https://github.com/ismip/ismip6-antarctic-ocean-forcing repo
+   somewhere
 
 3. In the directory where you plan to process the data, create a link to the
    `ismip6_ocean_forcing` subdirectory (not the repo, but one directory inside)

--- a/example_usage/cori/combine_all.py
+++ b/example_usage/cori/combine_all.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+import os
+import xarray
+import numpy
+
+def combine(start, end, model, climFirstYear=1995, climLastYear=2014):
+
+    climYears = '{:04d}-{:04d}'.format(climFirstYear, climLastYear)
+    
+    units = {'temperature': 'Degrees C',
+             'salinity': 'PSU',
+             'thermal_forcing': 'Degrees C'}
+    
+    longNames = {'temperature': 'In Situ Seawater Temperature',
+                 'salinity': 'Seawater Salinity',
+                 'thermal_forcing': 'Thermal Forcing (in situ Temperature minus'
+                                    ' freezing temperature)'}
+    
+    for firstYear, lastYear in [(start, climFirstYear-1), (climFirstYear, end)]:
+        outFolder = '{:04d}-{:04d}'.format(firstYear, lastYear)
+        try:
+            os.makedirs(outFolder)
+        except OSError:
+            pass
+        for field in ['temperature', 'salinity', 'thermal_forcing']:
+            outFileName = '{}/{}_{}_8km_x_60m.nc'.format(outFolder, model,
+                                                         field)
+            print(outFileName)
+            inFileNames = []
+            for first in range(firstYear, lastYear, 20):
+                last = min(first + 19, lastYear)
+                inFileNames.append(
+                   '{:04d}-{:04d}/anomaly_{:04d}-{:04d}_plus_obs/'
+                   '{}_{}_8km_x_60m.nc'.format(first, last, climFirstYear,
+                                               climLastYear, model, field))
+            ds = xarray.open_mfdataset(inFileNames, combine='nested',
+                                       concat_dim='time')
+            ds[field] = ds[field].astype(numpy.float32)
+            ds[field].attrs['units'] = units[field]
+            ds[field].attrs['long_name'] = longNames[field]
+            ds.to_netcdf(outFileName)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", dest="start", type=int,
+                    help="start year of the time series")
+    parser.add_argument("-e", dest="end", type=int,
+                    help="end year of the time series")
+    parser.add_argument("-m", dest="model", type=str,
+                    help="name of the model")
+    args = parser.parse_args() 
+
+    setup_years(args.start, args.end, args.model, args.scenario, args.ensemble)
+    setup_decades(args.start, args.end, args.model)
+

--- a/example_usage/cori/combine_all.py
+++ b/example_usage/cori/combine_all.py
@@ -2,6 +2,8 @@
 import os
 import xarray
 import numpy
+import argparse
+
 
 def combine(start, end, model, climFirstYear=1995, climLastYear=2014):
 
@@ -17,6 +19,8 @@ def combine(start, end, model, climFirstYear=1995, climLastYear=2014):
                                     ' freezing temperature)'}
     
     for firstYear, lastYear in [(start, climFirstYear-1), (climFirstYear, end)]:
+        if(firstYear > lastYear):
+            continue
         outFolder = '{:04d}-{:04d}'.format(firstYear, lastYear)
         try:
             os.makedirs(outFolder)
@@ -51,6 +55,5 @@ if __name__ == '__main__':
                     help="name of the model")
     args = parser.parse_args() 
 
-    setup_years(args.start, args.end, args.model, args.scenario, args.ensemble)
-    setup_decades(args.start, args.end, args.model)
+    combine(args.start, args.end, args.model)
 

--- a/example_usage/cori/combine_all.py
+++ b/example_usage/cori/combine_all.py
@@ -7,19 +7,17 @@ import argparse
 
 def combine(start, end, model, climFirstYear=1995, climLastYear=2014):
 
-    climYears = '{:04d}-{:04d}'.format(climFirstYear, climLastYear)
-    
     units = {'temperature': 'Degrees C',
              'salinity': 'PSU',
              'thermal_forcing': 'Degrees C'}
-    
+
     longNames = {'temperature': 'In Situ Seawater Temperature',
                  'salinity': 'Seawater Salinity',
                  'thermal_forcing': 'Thermal Forcing (in situ Temperature minus'
                                     ' freezing temperature)'}
-    
+
     for firstYear, lastYear in [(start, climFirstYear-1), (climFirstYear, end)]:
-        if(firstYear > lastYear):
+        if firstYear > lastYear:
             continue
         outFolder = '{:04d}-{:04d}'.format(firstYear, lastYear)
         try:
@@ -48,12 +46,11 @@ def combine(start, end, model, climFirstYear=1995, climLastYear=2014):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", dest="start", type=int,
-                    help="start year of the time series")
+                        help="start year of the time series")
     parser.add_argument("-e", dest="end", type=int,
-                    help="end year of the time series")
+                        help="end year of the time series")
     parser.add_argument("-m", dest="model", type=str,
-                    help="name of the model")
-    args = parser.parse_args() 
+                        help="name of the model")
+    args = parser.parse_args()
 
     combine(args.start, args.end, args.model)
-

--- a/example_usage/cori/setup_years_decades.py
+++ b/example_usage/cori/setup_years_decades.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+import os
+import argparse
+import numpy
+
+
+def replace(inFileName, outFileName, replacements):
+    with open(inFileName, 'rt') as fin:
+        with open(outFileName, 'wt') as fout:
+            for line in fin:
+                for orig in replacements:
+                    line = line.replace(orig, replacements[orig])
+                fout.write(line)
+
+
+def setup_years(start, end, model, scenario, ensemble):
+    for tIndex, year in enumerate(range(start, end+1)):
+        yearString = '{:04d}'.format(year)
+        print(yearString)
+        try:
+            os.makedirs(yearString)
+        except OSError:
+            pass
+    
+        replacements = {'@tIndex': '{}'.format(tIndex),
+                        '@modelLower': model.lower(),
+                        '@modelUpper': model,
+                        '@start': '{}'.format(start),
+                        '@end': '{}'.format(end),
+                        '@ensemble': ensemble,
+                        '@scenario': scenario,
+                        '@year': yearString}
+        templateFileName = '../templates/config.template'
+        outFileName = '{}/config.{}'.format(yearString, model.lower())
+        replace(templateFileName, outFileName, replacements)
+        templateFileName = '../templates/job_script_template.bash'
+        outFileName = '{}/job_script.bash'.format(yearString)
+        replace(templateFileName, outFileName, replacements)
+
+def setup_decades(start, end, model, climStart=1995, climEnd=2014,
+                  block=20):
+    
+    climOutFolder = '{:04d}-{:04d}'.format(climStart, climEnd)
+    climFolders = ', '.join(['{:04d}'.format(year) for year in
+                             range(climStart, climEnd+1)])
+
+    histStart = numpy.array(range(start, climStart-1, block), dtype=int)
+    histEnd = numpy.minimum(histStart+block-1, climStart-1)
+    
+    scenarioStart = numpy.array(range(climStart, end, block), dtype=int)
+    scenarioEnd = numpy.minimum(scenarioStart+block-1, end)
+    
+    firstYears = numpy.append(histStart, scenarioStart)
+    lastYears = numpy.append(histEnd, scenarioEnd)
+
+    for firstYear, lastYear in zip(firstYears, lastYears):
+        outFolder = '{:04d}-{:04d}'.format(firstYear, lastYear)
+        folders = ', '.join(['{:04d}'.format(year) for year in
+                             range(firstYear, lastYear+1)])
+        print(outFolder)
+        try:
+            os.makedirs(outFolder)
+        except OSError:
+            pass
+    
+        replacements = {'@outFolder': outFolder,
+                        '@folders': folders,
+                        '@modelLower': model.lower(),
+                        '@modelUpper': model,
+                        '@years': outFolder,
+                        '@tIndexMin': '{}'.format(firstYear-1850),
+                        '@tIndexMax': '{}'.format(lastYear-1850),
+                        '@climDecades': climOutFolder,
+                        '@climFolders': climFolders,
+                        '@climFirstTIndex': '0',
+                        '@climLastTIndex': '{}'.format(climEnd-climStart)}
+        templateFileName = '../templates/config.combine_template'
+        outFileName = '{}/config.{}'.format(outFolder, model.lower())
+        replace(templateFileName, outFileName, replacements)
+        templateFileName = '../templates/job_script_combine_template.bash'
+        outFileName = '{}/job_script.bash'.format(outFolder)
+        replace(templateFileName, outFileName, replacements)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", dest="start", type=int,
+                    help="start year of the time series")
+    parser.add_argument("-e", dest="end", type=int,
+                    help="end year of the time series")
+    parser.add_argument("-m", dest="model", type=str,
+                    help="name of the model")
+    parser.add_argument("--scenario", dest="scenario", type=str,
+                    help="scenario (rcp85, ssp585, etc.)")
+    parser.add_argument("--ensemble", dest="ensemble", type=str,
+                    help="ensemble member (r1i1p1, etc.)")
+    args = parser.parse_args() 
+
+    setup_years(args.start, args.end, args.model, args.scenario, args.ensemble)
+    setup_decades(args.start, args.end, args.model)
+

--- a/example_usage/cori/setup_years_decades.py
+++ b/example_usage/cori/setup_years_decades.py
@@ -21,7 +21,7 @@ def setup_years(start, end, model, scenario, ensemble):
             os.makedirs(yearString)
         except OSError:
             pass
-    
+
         replacements = {'@tIndex': '{}'.format(tIndex),
                         '@modelLower': model.lower(),
                         '@modelUpper': model,
@@ -37,19 +37,20 @@ def setup_years(start, end, model, scenario, ensemble):
         outFileName = '{}/job_script.bash'.format(yearString)
         replace(templateFileName, outFileName, replacements)
 
+
 def setup_decades(start, end, model, climStart=1995, climEnd=2014,
                   block=20):
-    
+
     climOutFolder = '{:04d}-{:04d}'.format(climStart, climEnd)
     climFolders = ', '.join(['{:04d}'.format(year) for year in
                              range(climStart, climEnd+1)])
 
     histStart = numpy.array(range(start, climStart-1, block), dtype=int)
     histEnd = numpy.minimum(histStart+block-1, climStart-1)
-    
+
     scenarioStart = numpy.array(range(climStart, end, block), dtype=int)
     scenarioEnd = numpy.minimum(scenarioStart+block-1, end)
-    
+
     firstYears = numpy.append(histStart, scenarioStart)
     lastYears = numpy.append(histEnd, scenarioEnd)
 
@@ -62,7 +63,7 @@ def setup_decades(start, end, model, climStart=1995, climEnd=2014,
             os.makedirs(outFolder)
         except OSError:
             pass
-    
+
         replacements = {'@outFolder': outFolder,
                         '@folders': folders,
                         '@modelLower': model.lower(),
@@ -85,17 +86,16 @@ def setup_decades(start, end, model, climStart=1995, climEnd=2014,
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", dest="start", type=int,
-                    help="start year of the time series")
+                        help="start year of the time series")
     parser.add_argument("-e", dest="end", type=int,
-                    help="end year of the time series")
+                        help="end year of the time series")
     parser.add_argument("-m", dest="model", type=str,
-                    help="name of the model")
+                        help="name of the model")
     parser.add_argument("--scenario", dest="scenario", type=str,
-                    help="scenario (rcp85, ssp585, etc.)")
+                        help="scenario (rcp85, ssp585, etc.)")
     parser.add_argument("--ensemble", dest="ensemble", type=str,
-                    help="ensemble member (r1i1p1, etc.)")
-    args = parser.parse_args() 
+                        help="ensemble member (r1i1p1, etc.)")
+    args = parser.parse_args()
 
     setup_years(args.start, args.end, args.model, args.scenario, args.ensemble)
     setup_decades(args.start, args.end, args.model)
-

--- a/example_usage/cori/templates/config.combine_template
+++ b/example_usage/cori/templates/config.combine_template
@@ -1,0 +1,60 @@
+[observations]
+compute = False
+
+[model]
+compute = False
+
+# The name of the model
+name = @modelUpper
+
+[climatology]
+## The range of time indices to use in climatology defining "present-day"
+# Should likely be the range of 1995-2012 to match the WOA climatology
+firstTIndex = @climFirstTIndex
+lastTIndex = @climLastTIndex
+
+# the output folder
+folder = climatology_@climDecades
+
+# dimension (either time or z, but not both) across which the individual data
+# sets differ
+dim = time
+
+# A comma-separated list of folders to combine
+folders = @climFolders
+
+# The output folder for the combined time series containing all years in the
+# climatology
+outFolder = climatology_@climDecades/output
+
+
+[output]
+# min/max time index (-1 for the end of the time variable)
+tIndexMin = @tIndexMin
+tIndexMax = @tIndexMax
+
+
+[combine]
+# is there data to combine
+combine = True
+
+# dimension (either time or z, but not both) across which the individual data
+# sets differ
+dim = time
+
+# A comma-separated list of folders to combine
+folders = @folders
+
+# The output folder
+outFolder = @outFolder/output
+
+
+[anomaly]
+## Config options related to the anomaly and its combination with WOA
+
+# the folder for the anomaly data set
+folder = @outFolder/anomaly_@climDecades
+
+# the folder for WOA plus the anomaly
+obsFolder = @outFolder/anomaly_@climDecades_plus_obs
+

--- a/example_usage/cori/templates/config.template
+++ b/example_usage/cori/templates/config.template
@@ -1,0 +1,39 @@
+[parallel]
+tasks = 8
+
+
+[observations]
+compute = False
+
+
+[output]
+## Options related to the time and depth indices to include in the analysis
+
+# min/max time index (-1 for the end of the time variable)
+tIndexMin = @tIndex
+tIndexMax = @tIndex
+
+
+[model]
+## Config options related to the model to extrapolate forcing for
+
+compute = True
+
+# The name of the model
+name = @modelUpper
+
+# Input files
+temperatureFileName = @modelLower/thetao_annual_@modelUpper_@scenario_@ensemble_@start01-@end12.nc
+salinityFileName = @modelLower/so_annual_@modelUpper_@scenario_@ensemble_@start01-@end12.nc
+
+# Variable names
+lon = lon
+lat = lat
+z = lev
+time = time
+temperature = thetao
+salinity = so
+z_bnds = lev_bnds
+
+# Output folder
+folder = @year

--- a/example_usage/cori/templates/job_script_combine_template.bash
+++ b/example_usage/cori/templates/job_script_combine_template.bash
@@ -1,0 +1,26 @@
+#!/bin/bash -l
+# comment out if using debug queue
+#SBATCH --partition=regular
+# comment in to get premium queue
+##SBATCH --qos=premium
+# comment in to get the debug queue
+##SBATCH --partition=debug
+# change number of nodes to change the number of parallel tasks
+# (anything between 1 and the total number of tasks to run)
+#SBATCH --nodes=1
+#SBATCH --time=0:30:00
+#SBATCH --account=m1041
+#SBATCH --job-name=@modelLower_@years
+#SBATCH --output=@modelLower/@years/ismip6.o%j
+#SBATCH --error=@modelLower/@years/ismip6.e%j
+#SBATCH -L SCRATCH
+#SBATCH -C haswell
+
+export OMP_NUM_THREADS=1
+
+module unload python python/base e3sm-unified
+source /global/homes/x/xylar/miniconda2/etc/profile.d/conda.sh
+conda activate ismip6_ocean_forcing
+export HDF5_USE_FILE_LOCKING=FALSE
+
+srun -N 1 -n 1 -c 1 python -m ismip6_ocean_forcing @modelLower/@years/config.@modelLower

--- a/example_usage/cori/templates/job_script_template.bash
+++ b/example_usage/cori/templates/job_script_template.bash
@@ -1,0 +1,26 @@
+#!/bin/bash -l
+# comment out if using debug queue
+#SBATCH --partition=regular
+# comment in to get premium queue
+##SBATCH --qos=premium
+# comment in to get the debug queue
+##SBATCH --partition=debug
+# change number of nodes to change the number of parallel tasks
+# (anything between 1 and the total number of tasks to run)
+#SBATCH --nodes=1
+#SBATCH --time=2:00:00
+#SBATCH --account=m1041
+#SBATCH --job-name=@modelLower_@year
+#SBATCH --output=@modelLower/@year/ismip6.o%j
+#SBATCH --error=@modelLower/@year/ismip6.e%j
+#SBATCH -L SCRATCH
+#SBATCH -C haswell
+
+export OMP_NUM_THREADS=1
+
+module unload python python/base e3sm-unified
+source /global/homes/x/xylar/miniconda2/etc/profile.d/conda.sh
+conda activate ismip6_ocean_forcing
+export HDF5_USE_FILE_LOCKING=FALSE
+
+srun -N 1 -n 1 -c 1 python -m ismip6_ocean_forcing @modelLower/@year/config.@modelLower

--- a/ismip6_ocean_forcing/en4/main.py
+++ b/ismip6_ocean_forcing/en4/main.py
@@ -130,6 +130,8 @@ def _bin_en4(config, inVarName, outVarName, startYear, endYear):
 
         lat = numpy.maximum(lat, -75.)
         for profile in range(depths.shape[0]):
+            if not (numpy.isfinite(x[profile]) and numpy.isfinite(y[profile])):
+                continue
             xBin = int((x[profile]-xMin)/dx)
             yBin = int((y[profile]-yMin)/dx)
             if xBin < 0 or xBin >= nx:

--- a/ismip6_ocean_forcing/extrap/vert.py
+++ b/ismip6_ocean_forcing/extrap/vert.py
@@ -41,7 +41,7 @@ def extrap_vert(config, inFileName, outFileName, fieldName, timeIndices=None):
             fieldLocal[invalid] = fieldAbove[invalid]
             field3D[tIndex, zIndex, :, :] = fieldLocal
 
-            widgets[0] = '  z={}/{}: '.format(zIndex+1, nz)
+            bar.widgets[0] = '  z={}/{}: '.format(zIndex+1, nz)
             bar.update(tIndex + nt*zIndex)
 
     bar.finish()

--- a/ismip6_ocean_forcing/model/anomaly.py
+++ b/ismip6_ocean_forcing/model/anomaly.py
@@ -57,7 +57,8 @@ def _combine_model_output(config, section):
             continue
 
         print('    {}'.format(outFileName))
-        ds = xarray.open_mfdataset(fileNames, concat_dim=combineDim)
+        ds = xarray.open_mfdataset(fileNames, combine='nested',
+                                   concat_dim=combineDim)
         for coord in ['lat', 'lon']:
             if coord in ds.coords and 'time' in ds.coords[coord].dims:
                 ds.coords[coord] = ds.coords[coord].isel(time=0, drop=True)

--- a/ismip6_ocean_forcing/model/remap.py
+++ b/ismip6_ocean_forcing/model/remap.py
@@ -242,7 +242,8 @@ def _remap(config, modelFolder):
         bar.finish()
 
         dsOut = xarray.open_mfdataset(
-            '{}/{}_t_*.nc'.format(progressDir, modelName), concat_dim='time')
+            '{}/{}_t_*.nc'.format(progressDir, modelName), combine='nested',
+            concat_dim='time')
 
         dsOut['z_bnds'] = ds.z_bnds
 

--- a/ismip6_ocean_forcing/preprocess/cesm2/README.md
+++ b/ismip6_ocean_forcing/preprocess/cesm2/README.md
@@ -1,18 +1,25 @@
 Download and Process CESM2 thetao and so
 ========================================
 
-These data are available on the ISMIP6 lftp server.  The files are in the
-subdirectory `/GSFC/Kate`.  The files needed are:
+An Earth System Grid account is required to download the CESM2
+CMIP6 data sets from which the forcing time series is derived.  Log
+in to your account, go to CMIP6, select CESM as the
+Source ID; historical as the Experiment IC; r11i1p1f1 as
+the Variant Label; and so and thetao in Variables.  Click "Search".  You many
+want to choose "Show All Replicas" and "Search" again.
 
-* `b.e21.BHIST.f09_g17.CMIP6-historical.011.pop.h.SALT.195001-199912.nc`
-* `b.e21.BHIST.f09_g17.CMIP6-historical.011.pop.h.SALT.200001-201412.nc`
-* `b.e21.BHIST.f09_g17.CMIP6-historical.011.pop.h.TEMP.195001-199912.nc`
-* `b.e21.BHIST.f09_g17.CMIP6-historical.011.pop.h.TEMP.200001-201412.nc`
-* `b.e21.BSSP585cmip6.f09_g17.CMIP6-SSP5-8.5.002.pop.h.SALT.201501-206412.nc`
-* `b.e21.BSSP585cmip6.f09_g17.CMIP6-SSP5-8.5.002.pop.h.SALT.206501-210012.nc`
-* `b.e21.BSSP585cmip6.f09_g17.CMIP6-SSP5-8.5.002.pop.h.TEMP.201501-206412.nc`
-* `b.e21.BSSP585cmip6.f09_g17.CMIP6-SSP5-8.5.002.pop.h.TEMP.206501-210012.nc`
+Download the WGET Script for the "gn" (native grid) verison of  each Variable.
+
+Now, for the ssp data, go to CMIP6, select CESM as the
+Source ID; ssp585 as the Experiment IC; r2i1p1f1 as
+the Variant Label; and so and thetao in Variables.  Click "Search".  You many
+want to choose "Show All Replicas" and "Search" again.
+
+Again, download the WGET Script for the "gn" version of each Variable.  Run all
+of the WGET scripts. If all goes correctly, you should only need to log in once
+with your OpenID to run all the WGET Scripts.
 
 Finally, run `process_cesm2_e21_f09_g17.py -o /path/to/cesm2/files/` with the
-path where the CESM2 data sets are stored.
+path where the CESM2 data sets are stored (or similarly for the "historical"
+script).
 

--- a/ismip6_ocean_forcing/preprocess/cesm2/process_cesm2_ssp585.py
+++ b/ismip6_ocean_forcing/preprocess/cesm2/process_cesm2_ssp585.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+import argparse
+import xarray
+import numpy
+import os
+import warnings
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-o', dest='out_dir', metavar='DIR', required=True,
+                    type=str, help='output directory')
+args = parser.parse_args()
+
+
+def compute_yearly_mean(inFileName, outFileName, tempFileName):
+    # crop to below 48 S and take annual mean over the data
+    if os.path.exists(outFileName):
+        return
+    print('{} to {}'.format(inFileName, outFileName))
+
+    dsIn = xarray.open_dataset(inFileName, chunks={'time': 24})
+    dsIn = dsIn.rename({'d2': 'bnds'})
+    ds = xarray.Dataset()
+    if 'so' in dsIn:
+        ds['so'] = dsIn['so']
+    if 'thetao' in dsIn:
+        ds['thetao'] = dsIn['thetao']
+    ds.coords['lev'] *= 0.01
+    ds.lev.attrs['units'] = 'm'
+    ds.lev.attrs['bounds'] = 'lev_bnds'
+    ds.coords['lev_bnds'] = dsIn.lev_bnds
+
+    # crop to Southern Ocean
+    minLat = ds.lat.min(dim='nlon')
+    mask = minLat <= -48.
+    yIndices = numpy.nonzero(mask.values)[0]
+    ds = ds.isel(nlat=yIndices)
+
+    # write out and read back to get a clean start
+    ds.to_netcdf(tempFileName)
+    ds.close()
+    ds = xarray.open_dataset(tempFileName)
+
+    # annual mean
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        ds = ds.groupby('time.year').mean('time', keep_attrs=True)
+
+    # convert back to CF-compliant time
+    ds = ds.rename({'year': 'time'})
+    ds['time'] = 365.0*ds.time
+    ds.time.attrs['bounds'] = "time_bnds"
+    ds.time.attrs['units'] = "days since 0000-01-01 00:00:00"
+    ds.time.attrs['calendar'] = "noleap"
+    ds.time.attrs['axis'] = "T"
+    ds.time.attrs['long_name'] = "time"
+    ds.time.attrs['standard_name'] = "time"
+
+    timeBounds = numpy.zeros((ds.sizes['time'], ds.sizes['bnds']))
+    timeBounds[:, 0] = ds.time.values
+    timeBounds[:, 1] = ds.time.values + 365
+    ds['time_bnds'] = (('time', 'bnds'), timeBounds)
+
+    ds = xarray.decode_cf(ds, use_cftime=True)
+
+    encoding = {'time': {'units': 'days since 0000-01-01'}}
+    ds.to_netcdf(outFileName, encoding=encoding)
+
+
+model = 'CESM2'
+run = 'r11i1p1f1'
+
+dates = {'thetao': ['195001-199912',
+                    '200001-201412'],
+         'so': ['195001-199912',
+                '200001-201412']}
+
+histFiles = {}
+for field in dates:
+    histFiles[field] = []
+    for date in dates[field]:
+        inFileName = '{}/{}_Omon_{}_historical_{}_gn_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        tempFileName = '{}/temp.nc'.format(args.out_dir)
+        outFileName = '{}/{}_annual_{}_historical_{}_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        compute_yearly_mean(inFileName, outFileName, tempFileName)
+        histFiles[field].append(outFileName)
+
+run = 'r2i1p1f1'
+dates = {'thetao': ['201501-206412',
+                    '206501-210012'],
+         'so': ['201501-206412',
+                '206501-210012']}
+for scenario in ['ssp585']:
+    scenarioFiles = {}
+    for field in dates:
+        scenarioFiles[field] = []
+        for date in dates[field]:
+            inFileName = '{}/{}_Omon_{}_{}_{}_gn_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            tempFileName = '{}/temp.nc'.format(args.out_dir)
+
+            outFileName = '{}/{}_annual_{}_{}_{}_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            compute_yearly_mean(inFileName, outFileName, tempFileName)
+            scenarioFiles[field].append(outFileName)
+
+    for field in ['so', 'thetao']:
+        outFileName = \
+            '{}/{}_annual_{}_{}_{}_199501-210012.nc'.format(
+                args.out_dir, field, model, scenario, run)
+        if not os.path.exists(outFileName):
+            print(outFileName)
+
+            # combine it all into a single data set
+            ds = xarray.open_mfdataset(histFiles[field] + scenarioFiles[field],
+                                       combine='nested', concat_dim='time',
+                                       use_cftime=True)
+
+            mask = ds['time.year'] >= 1995
+            tIndices = numpy.nonzero(mask.values)[0]
+            ds = ds.isel(time=tIndices)
+            encoding = {'time': {'units': 'days since 0000-01-01'}}
+            ds.to_netcdf(outFileName, encoding=encoding)

--- a/ismip6_ocean_forcing/preprocess/cnrm/process_cnrm_cm6_1_historical.py
+++ b/ismip6_ocean_forcing/preprocess/cnrm/process_cnrm_cm6_1_historical.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import argparse
+import xarray
+import numpy
+import os
+import warnings
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-o', dest='out_dir', metavar='DIR', required=True,
+                    type=str, help='output directory')
+args = parser.parse_args()
+
+
+def compute_yearly_mean(inFileName, outFileName):
+    # crop to below 48 S and take annual mean over the data
+    if os.path.exists(outFileName):
+        return
+    print('{} to {}'.format(inFileName, outFileName))
+
+    ds = xarray.open_dataset(inFileName)
+    ds = ds.rename({'lev_bounds': 'lev_bnds',
+                    'bounds_lon': 'lon_vertices',
+                    'bounds_lat': 'lat_vertices',
+                    'axis_nbounds': 'bnds'})
+
+    ds = ds.drop('time_bounds')
+
+    # crop to Southern Ocean
+    minLat = ds.lat.min(dim='x')
+    mask = minLat <= -48.
+    yIndices = numpy.nonzero(mask.values)[0]
+    ds = ds.isel(y=yIndices)
+
+    for coord in ['lev_bnds', 'lon_vertices', 'lat_vertices']:
+        ds.coords[coord] = ds[coord]
+
+    # annual mean
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        ds = ds.groupby('time.year').mean('time', keep_attrs=True)
+
+    # convert back to CF-compliant time
+    ds = ds.rename({'year': 'time'})
+    ds['time'] = 365.0*ds.time
+    ds.time.attrs['bounds'] = "time_bnds"
+    ds.time.attrs['units'] = "days since 0000-01-01 00:00:00"
+    ds.time.attrs['calendar'] = "noleap"
+    ds.time.attrs['axis'] = "T"
+    ds.time.attrs['long_name'] = "time"
+    ds.time.attrs['standard_name'] = "time"
+
+    timeBounds = numpy.zeros((ds.sizes['time'], ds.sizes['bnds']))
+    timeBounds[:, 0] = ds.time.values
+    timeBounds[:, 1] = ds.time.values + 365
+    ds['time_bnds'] = (('time', 'bnds'), timeBounds)
+
+    ds = xarray.decode_cf(ds, use_cftime=True)
+
+    encoding = {'time': {'units': 'days since 0000-01-01'}}
+    ds.to_netcdf(outFileName, encoding=encoding)
+
+
+model = 'CNRM-CM6-1'
+run = 'r1i1p1f2'
+
+dates = {'thetao': ['185001-187412',
+                    '187501-189912',
+                    '190001-192412',
+                    '192501-194912',
+                    '195001-197412',
+                    '197501-199912',
+                    '200001-201412'],
+         'so': ['185001-189912',
+                '190001-194912',
+                '195001-199912',
+                '200001-201412']}
+
+histFiles = {}
+for field in dates:
+    histFiles[field] = []
+    for date in dates[field]:
+        inFileName = '{}/{}_Omon_{}_historical_{}_gn_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        outFileName = '{}/{}_annual_{}_historical_{}_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        compute_yearly_mean(inFileName, outFileName)
+        histFiles[field].append(outFileName)
+
+dates = {'thetao': [],
+         'so': []}
+for scenario in ['ssp126', 'ssp585']:
+    scenarioFiles = {}
+    for field in dates:
+        scenarioFiles[field] = []
+        for date in dates[field]:
+            inFileName = '{}/{}_Omon_{}_{}_{}_gn_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            outFileName = '{}/{}_annual_{}_{}_{}_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            compute_yearly_mean(inFileName, outFileName)
+            scenarioFiles[field].append(outFileName)
+
+for scenario in ['historical']:
+    for field in ['so', 'thetao']:
+        outFileName = \
+            '{}/{}_annual_{}_{}_{}_185001-201412.nc'.format(
+                args.out_dir, field, model, scenario, run)
+        if not os.path.exists(outFileName):
+            print(outFileName)
+
+            # combine it all into a single data set
+            ds = xarray.open_mfdataset(histFiles[field] + scenarioFiles[field],
+                                       combine='nested', concat_dim='time',
+                                       use_cftime=True)
+
+            mask = ds['time.year'] <= 2014
+            tIndices = numpy.nonzero(mask.values)[0]
+            ds = ds.isel(time=tIndices)
+            encoding = {'time': {'units': 'days since 0000-01-01'}}
+            ds.to_netcdf(outFileName, encoding=encoding)

--- a/ismip6_ocean_forcing/preprocess/cnrm/process_cnrm_esm2_1_historical.py
+++ b/ismip6_ocean_forcing/preprocess/cnrm/process_cnrm_esm2_1_historical.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import argparse
+import xarray
+import numpy
+import os
+import warnings
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-o', dest='out_dir', metavar='DIR', required=True,
+                    type=str, help='output directory')
+args = parser.parse_args()
+
+
+def compute_yearly_mean(inFileName, outFileName):
+    # crop to below 48 S and take annual mean over the data
+    if os.path.exists(outFileName):
+        return
+    print('{} to {}'.format(inFileName, outFileName))
+
+    ds = xarray.open_dataset(inFileName)
+    ds = ds.rename({'lev_bounds': 'lev_bnds',
+                    'bounds_lon': 'lon_vertices',
+                    'bounds_lat': 'lat_vertices',
+                    'axis_nbounds': 'bnds'})
+
+    ds = ds.drop('time_bounds')
+
+    # crop to Southern Ocean
+    minLat = ds.lat.min(dim='x')
+    mask = minLat <= -48.
+    yIndices = numpy.nonzero(mask.values)[0]
+    ds = ds.isel(y=yIndices)
+
+    for coord in ['lev_bnds', 'lon_vertices', 'lat_vertices']:
+        ds.coords[coord] = ds[coord]
+
+    # annual mean
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        ds = ds.groupby('time.year').mean('time', keep_attrs=True)
+
+    # convert back to CF-compliant time
+    ds = ds.rename({'year': 'time'})
+    ds['time'] = 365.0*ds.time
+    ds.time.attrs['bounds'] = "time_bnds"
+    ds.time.attrs['units'] = "days since 0000-01-01 00:00:00"
+    ds.time.attrs['calendar'] = "noleap"
+    ds.time.attrs['axis'] = "T"
+    ds.time.attrs['long_name'] = "time"
+    ds.time.attrs['standard_name'] = "time"
+
+    timeBounds = numpy.zeros((ds.sizes['time'], ds.sizes['bnds']))
+    timeBounds[:, 0] = ds.time.values
+    timeBounds[:, 1] = ds.time.values + 365
+    ds['time_bnds'] = (('time', 'bnds'), timeBounds)
+
+    ds = xarray.decode_cf(ds, use_cftime=True)
+
+    encoding = {'time': {'units': 'days since 0000-01-01'}}
+    ds.to_netcdf(outFileName, encoding=encoding)
+
+
+model = 'CNRM-ESM2-1'
+run = 'r1i1p1f2'
+
+dates = {'thetao': ['185001-187412',
+                    '187501-189912',
+                    '190001-192412',
+                    '192501-194912',
+                    '195001-197412',
+                    '197501-199912',
+                    '200001-201412'],
+         'so': ['185001-189912',
+                '190001-194912',
+                '195001-199912',
+                '200001-201412']}
+
+histFiles = {}
+for field in dates:
+    histFiles[field] = []
+    for date in dates[field]:
+        inFileName = '{}/{}_Omon_{}_historical_{}_gn_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        outFileName = '{}/{}_annual_{}_historical_{}_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        compute_yearly_mean(inFileName, outFileName)
+        histFiles[field].append(outFileName)
+
+dates = {'thetao': [],
+         'so': []}
+for scenario in ['ssp585']:
+    scenarioFiles = {}
+    for field in dates:
+        scenarioFiles[field] = []
+        for date in dates[field]:
+            inFileName = '{}/{}_Omon_{}_{}_{}_gn_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            outFileName = '{}/{}_annual_{}_{}_{}_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            compute_yearly_mean(inFileName, outFileName)
+            scenarioFiles[field].append(outFileName)
+
+for scenario in ['historical']:
+    for field in ['so', 'thetao']:
+        outFileName = \
+            '{}/{}_annual_{}_{}_{}_185001-201412.nc'.format(
+                args.out_dir, field, model, scenario, run)
+        if not os.path.exists(outFileName):
+            print(outFileName)
+
+            # combine it all into a single data set
+            ds = xarray.open_mfdataset(histFiles[field] + scenarioFiles[field],
+                                       combine='nested', concat_dim='time',
+                                       use_cftime=True)
+
+            mask = ds['time.year'] <= 2014
+            tIndices = numpy.nonzero(mask.values)[0]
+            ds = ds.isel(time=tIndices)
+            encoding = {'time': {'units': 'days since 0000-01-01'}}
+            ds.to_netcdf(outFileName, encoding=encoding)

--- a/ismip6_ocean_forcing/preprocess/csiro_mk3_6_0/process_csiro_mk3_6_0_historical.py
+++ b/ismip6_ocean_forcing/preprocess/csiro_mk3_6_0/process_csiro_mk3_6_0_historical.py
@@ -6,6 +6,7 @@ import numpy
 import os
 import warnings
 
+
 parser = argparse.ArgumentParser(
     description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument('-o', dest='out_dir', metavar='DIR',
@@ -53,7 +54,7 @@ def compute_yearly_mean(inFileName, outFileName):
 starts = list(range(1850, 2010, 10))
 ends = list(range(1859, 2010, 10))
 ends[-1] = 2005
-dates = ['{}01-{}12'.format(starts[index], ends[index]) for index in 
+dates = ['{}01-{}12'.format(starts[index], ends[index]) for index in
          range(len(starts))]
 
 for date in dates:
@@ -61,8 +62,9 @@ for date in dates:
         inFileName = '{}/{}_Omon_CSIRO-Mk3-6-0_historical_r1i1p1_{}.nc'.format(
             args.out_dir, field, date)
 
-        outFileName = '{}/{}_annual_CSIRO-Mk3-6-0_historical_r1i1p1_{}.nc'.format(
-            args.out_dir, field, date)
+        outFileName = \
+            '{}/{}_annual_CSIRO-Mk3-6-0_historical_r1i1p1_{}.nc'.format(
+                args.out_dir, field, date)
 
         compute_yearly_mean(inFileName, outFileName)
 
@@ -88,7 +90,7 @@ for field in ['so', 'thetao']:
         # combine it all into a single data set
         ds = xarray.open_mfdataset(
             '{}/{}_annual_CSIRO-Mk3-6-0_*_r1i1p1_*.nc'.format(
-                args.out_dir, field), 
+                args.out_dir, field),
             combine='nested', concat_dim='time', use_cftime=True)
         mask = ds['time.year'] <= 2014
         tIndices = numpy.nonzero(mask.values)[0]

--- a/ismip6_ocean_forcing/preprocess/csiro_mk3_6_0/process_csiro_mk3_6_0_historical.py
+++ b/ismip6_ocean_forcing/preprocess/csiro_mk3_6_0/process_csiro_mk3_6_0_historical.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+import argparse
+import xarray
+import numpy
+import os
+import warnings
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-o', dest='out_dir', metavar='DIR',
+                    type=str, help='output directory')
+args = parser.parse_args()
+
+
+def compute_yearly_mean(inFileName, outFileName):
+    # crop to below 48 S and take annual mean from monthly data
+    if os.path.exists(outFileName):
+        return
+    print('{} to {}'.format(inFileName, outFileName))
+
+    ds = xarray.open_dataset(inFileName)
+
+    # crop to Southern Ocean
+    ds = ds.isel(lat=slice(0, 44))
+
+    for coord in ['lev_bnds', 'lon_bnds', 'lat_bnds']:
+        ds.coords[coord] = ds[coord]
+
+    # annual mean
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        ds = ds.groupby('time.year').mean('time', keep_attrs=True)
+
+    # convert back to CF-compliant time
+    ds = ds.rename({'year': 'time'})
+    ds['time'] = 365.0*ds.time
+    ds.time.attrs['bounds'] = "time_bnds"
+    ds.time.attrs['units'] = "days since 0000-01-01 00:00:00"
+    ds.time.attrs['calendar'] = "noleap"
+    ds.time.attrs['axis'] = "T"
+    ds.time.attrs['long_name'] = "time"
+    ds.time.attrs['standard_name'] = "time"
+
+    timeBounds = numpy.zeros((ds.sizes['time'], ds.sizes['bnds']))
+    timeBounds[:, 0] = 365.0*ds.time.values
+    timeBounds[:, 1] = 365.0*(ds.time.values+1)
+    ds['time_bnds'] = (('time', 'bnds'), timeBounds)
+
+    ds.to_netcdf(outFileName)
+
+
+starts = list(range(1850, 2010, 10))
+ends = list(range(1859, 2010, 10))
+ends[-1] = 2005
+dates = ['{}01-{}12'.format(starts[index], ends[index]) for index in 
+         range(len(starts))]
+
+for date in dates:
+    for field in ['so', 'thetao']:
+        inFileName = '{}/{}_Omon_CSIRO-Mk3-6-0_historical_r1i1p1_{}.nc'.format(
+            args.out_dir, field, date)
+
+        outFileName = '{}/{}_annual_CSIRO-Mk3-6-0_historical_r1i1p1_{}.nc'.format(
+            args.out_dir, field, date)
+
+        compute_yearly_mean(inFileName, outFileName)
+
+dates = ['200601-201512']
+
+for date in dates:
+    for field in ['so', 'thetao']:
+        inFileName = '{}/{}_Omon_CSIRO-Mk3-6-0_rcp85_r1i1p1_{}.nc'.format(
+            args.out_dir, field, date)
+
+        outFileName = '{}/{}_annual_CSIRO-Mk3-6-0_rcp85_r1i1p1_{}.nc'.format(
+            args.out_dir, field, date)
+
+        compute_yearly_mean(inFileName, outFileName)
+
+for field in ['so', 'thetao']:
+    outFileName = \
+        '{}/{}_annual_CSIRO-Mk3-6-0_rcp85_r1i1p1_185001-201412.nc'.format(
+            args.out_dir, field)
+    if not os.path.exists(outFileName):
+        print(outFileName)
+
+        # combine it all into a single data set
+        ds = xarray.open_mfdataset(
+            '{}/{}_annual_CSIRO-Mk3-6-0_*_r1i1p1_*.nc'.format(
+                args.out_dir, field), 
+            combine='nested', concat_dim='time', use_cftime=True)
+        mask = ds['time.year'] <= 2014
+        tIndices = numpy.nonzero(mask.values)[0]
+        ds = ds.isel(time=tIndices)
+        encoding = {'time': {'units': 'days since 0000-01-01'}}
+        ds.to_netcdf(outFileName)

--- a/ismip6_ocean_forcing/preprocess/hadgem2_es/process_hadgem2_es_historical.py
+++ b/ismip6_ocean_forcing/preprocess/hadgem2_es/process_hadgem2_es_historical.py
@@ -50,7 +50,20 @@ def compute_yearly_mean(inFileName, outFileName):
     ds.to_netcdf(outFileName)
 
 
-dates = ['198912-199911',
+dates = ['185912-186911',
+         '186912-187911',
+         '187912-188911',
+         '188912-189911',
+         '189912-190911',
+         '190912-191911',
+         '191912-192911',
+         '192912-193911',
+         '193912-194911',
+         '194912-195911',
+         '195912-196911',
+         '196912-197911',
+         '197912-198911',
+         '198912-199911',
          '199912-200512']
 
 for date in dates:
@@ -63,17 +76,7 @@ for date in dates:
 
         compute_yearly_mean(inFileName, outFileName)
 
-dates = ['200512-201511',
-         '201512-202511',
-         '202512-203511',
-         '203512-204511',
-         '204512-205511',
-         '205512-206511',
-         '206512-207511',
-         '207512-208511',
-         '208512-209511',
-         '209512-209912',
-         '209912-210911']
+dates = ['200512-201511']
 
 for date in dates:
     for field in ['so', 'thetao']:
@@ -87,7 +90,7 @@ for date in dates:
 
 for field in ['so', 'thetao']:
     outFileName = \
-        '{}/{}_annual_HadGEM2-ES_rcp85_r1i1p1_199001-210012.nc'.format(
+        '{}/{}_annual_HadGEM2-ES_rcp85_r1i1p1_186001-201412.nc'.format(
             args.out_dir, field)
     if not os.path.exists(outFileName):
         print(outFileName)
@@ -97,4 +100,5 @@ for field in ['so', 'thetao']:
             '{}/{}_annual_HadGEM2-ES_*_r1i1p1_*.nc'.format(
                 args.out_dir, field), combine='nested', concat_dim='time',
                 decode_times=False)
+        ds = ds.isel(time=slice(1, ds.sizes['time']-1))
         ds.to_netcdf(outFileName)

--- a/ismip6_ocean_forcing/preprocess/hadgem2_es/process_hadgem2_es_historical.py
+++ b/ismip6_ocean_forcing/preprocess/hadgem2_es/process_hadgem2_es_historical.py
@@ -98,7 +98,7 @@ for field in ['so', 'thetao']:
         # combine it all into a single data set
         ds = xarray.open_mfdataset(
             '{}/{}_annual_HadGEM2-ES_*_r1i1p1_*.nc'.format(
-                args.out_dir, field), combine='nested', concat_dim='time',
-                decode_times=False)
+                args.out_dir, field),
+            combine='nested', concat_dim='time', decode_times=False)
         ds = ds.isel(time=slice(1, ds.sizes['time']-1))
         ds.to_netcdf(outFileName)

--- a/ismip6_ocean_forcing/preprocess/hadgem2_es/process_hadgem2_es_rcp85.py
+++ b/ismip6_ocean_forcing/preprocess/hadgem2_es/process_hadgem2_es_rcp85.py
@@ -95,6 +95,6 @@ for field in ['so', 'thetao']:
         # combine it all into a single data set
         ds = xarray.open_mfdataset(
             '{}/{}_annual_HadGEM2-ES_*_r1i1p1_*.nc'.format(
-                args.out_dir, field), combine='nested', concat_dim='time',
-                decode_times=False)
+                args.out_dir, field),
+            combine='nested', concat_dim='time', decode_times=False)
         ds.to_netcdf(outFileName)

--- a/ismip6_ocean_forcing/preprocess/ipsl_cm5a_mr/process_ipsl_cm5a_mr_historical.py
+++ b/ismip6_ocean_forcing/preprocess/ipsl_cm5a_mr/process_ipsl_cm5a_mr_historical.py
@@ -63,8 +63,9 @@ for date in dates:
         inFileName = '{}/{}_Omon_IPSL-CM5A-MR_historical_r1i1p1_{}.nc'.format(
             args.out_dir, field, date)
 
-        outFileName = '{}/{}_annual_IPSL-CM5A-MR_historical_r1i1p1_{}.nc'.format(
-            args.out_dir, field, date)
+        outFileName = \
+            '{}/{}_annual_IPSL-CM5A-MR_historical_r1i1p1_{}.nc'.format(
+                args.out_dir, field, date)
 
         compute_yearly_mean(inFileName, outFileName)
 
@@ -95,7 +96,7 @@ for scenario in ['rcp26', 'rcp85']:
                 files = files + glob.glob(
                     '{}/{}_annual_IPSL-CM5A-MR_{}_r1i1p1_*.nc'.format(
                          args.out_dir, field, expt))
-            
+
             ds = xarray.open_mfdataset(files, combine='nested',
                                        concat_dim='time', use_cftime=True)
             mask = ds['time.year'] <= 2014

--- a/ismip6_ocean_forcing/preprocess/ipsl_cm5a_mr/process_ipsl_cm5a_mr_historical.py
+++ b/ismip6_ocean_forcing/preprocess/ipsl_cm5a_mr/process_ipsl_cm5a_mr_historical.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+import argparse
+import xarray
+import numpy
+import os
+import warnings
+import glob
+
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-o', dest='out_dir', metavar='DIR',
+                    type=str, help='output directory')
+args = parser.parse_args()
+
+
+def compute_yearly_mean(inFileName, outFileName):
+    # crop to below 48 S and take annual mean from monthly data
+    if os.path.exists(outFileName):
+        return
+
+    print('{} to {}'.format(inFileName, outFileName))
+
+    ds = xarray.open_dataset(inFileName)
+
+    for coord in ['lev_bnds', 'lon_vertices', 'lat_vertices']:
+        ds.coords[coord] = ds[coord]
+
+    # crop to Southern Ocean
+    ds = ds.where(ds.lat <= -48., drop=True)
+
+    # annual mean
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        ds = ds.groupby('time.year').mean('time', keep_attrs=True)
+
+    # convert back to CF-compliant time
+    ds = ds.rename({'year': 'time'})
+    ds['time'] = 365.0*ds.time
+    ds.time.attrs['bounds'] = "time_bnds"
+    ds.time.attrs['units'] = "days since 0000-01-01 00:00:00"
+    ds.time.attrs['calendar'] = "noleap"
+    ds.time.attrs['axis'] = "T"
+    ds.time.attrs['long_name'] = "time"
+    ds.time.attrs['standard_name'] = "time"
+
+    timeBounds = numpy.zeros((ds.sizes['time'], ds.sizes['bnds']))
+    timeBounds[:, 0] = 365.0*ds.time.values
+    timeBounds[:, 1] = 365.0*(ds.time.values+1)
+    ds['time_bnds'] = (('time', 'bnds'), timeBounds)
+
+    ds.to_netcdf(outFileName)
+
+
+dates = ['185001-189912',
+         '190001-194912',
+         '195001-199912',
+         '200001-200512']
+
+for date in dates:
+    for field in ['so', 'thetao']:
+        inFileName = '{}/{}_Omon_IPSL-CM5A-MR_historical_r1i1p1_{}.nc'.format(
+            args.out_dir, field, date)
+
+        outFileName = '{}/{}_annual_IPSL-CM5A-MR_historical_r1i1p1_{}.nc'.format(
+            args.out_dir, field, date)
+
+        compute_yearly_mean(inFileName, outFileName)
+
+dates = ['200601-205512']
+
+for scenario in ['rcp26', 'rcp85']:
+    for date in dates:
+        for field in ['so', 'thetao']:
+            inFileName = '{}/{}_Omon_IPSL-CM5A-MR_{}_r1i1p1_{}.nc'.format(
+                args.out_dir, field, scenario, date)
+
+            outFileName = '{}/{}_annual_IPSL-CM5A-MR_{}_r1i1p1_{}.nc'.format(
+                args.out_dir, field, scenario, date)
+
+            compute_yearly_mean(inFileName, outFileName)
+
+for scenario in ['rcp26', 'rcp85']:
+    for field in ['so', 'thetao']:
+        outFileName = \
+            '{}/{}_annual_IPSL-CM5A-MR_{}_r1i1p1_185001-201412.nc'.format(
+                args.out_dir, field, scenario)
+        if not os.path.exists(outFileName):
+            print(outFileName)
+
+            # combine it all into a single data set
+            files = list()
+            for expt in ['historical', scenario]:
+                files = files + glob.glob(
+                    '{}/{}_annual_IPSL-CM5A-MR_{}_r1i1p1_*.nc'.format(
+                         args.out_dir, field, expt))
+            
+            ds = xarray.open_mfdataset(files, combine='nested',
+                                       concat_dim='time', use_cftime=True)
+            mask = ds['time.year'] <= 2014
+            tIndices = numpy.nonzero(mask.values)[0]
+            ds = ds.isel(time=tIndices)
+            encoding = {'time': {'units': 'days since 0000-01-01'}}
+            ds.to_netcdf(outFileName)

--- a/ismip6_ocean_forcing/preprocess/ukesm1/process_historical_ukesm1_0_ll.py
+++ b/ismip6_ocean_forcing/preprocess/ukesm1/process_historical_ukesm1_0_ll.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+import argparse
+import xarray
+import numpy
+import os
+import warnings
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-o', dest='out_dir', metavar='DIR', required=True,
+                    type=str, help='output directory')
+args = parser.parse_args()
+
+
+def compute_yearly_mean(inFileName, outFileName):
+    # crop to below 48 S and take annual mean over the data
+    if os.path.exists(outFileName):
+        return
+    print('{} to {}'.format(inFileName, outFileName))
+
+    ds = xarray.open_dataset(inFileName)
+    ds = ds.rename({'longitude': 'lon',
+                    'latitude': 'lat',
+                    'vertices_longitude': 'lon_vertices',
+                    'vertices_latitude': 'lat_vertices'})
+
+    ds = ds.drop('time_bnds')
+
+    # crop to Southern Ocean
+    minLat = ds.lat.min(dim='i')
+    mask = minLat <= -48.
+    yIndices = numpy.nonzero(mask.values)[0]
+    ds = ds.isel(j=yIndices)
+
+    for coord in ['lev_bnds', 'lon_vertices', 'lat_vertices']:
+        ds.coords[coord] = ds[coord]
+
+    # annual mean
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        ds = ds.groupby('time.year').mean('time', keep_attrs=True)
+
+    # convert back to CF-compliant time
+    ds = ds.rename({'year': 'time'})
+    ds['time'] = 365.0*ds.time
+    ds.time.attrs['bounds'] = "time_bnds"
+    ds.time.attrs['units'] = "days since 0000-01-01 00:00:00"
+    ds.time.attrs['calendar'] = "noleap"
+    ds.time.attrs['axis'] = "T"
+    ds.time.attrs['long_name'] = "time"
+    ds.time.attrs['standard_name'] = "time"
+
+    timeBounds = numpy.zeros((ds.sizes['time'], ds.sizes['bnds']))
+    timeBounds[:, 0] = ds.time.values
+    timeBounds[:, 1] = ds.time.values + 365
+    ds['time_bnds'] = (('time', 'bnds'), timeBounds)
+
+    ds = xarray.decode_cf(ds, use_cftime=True)
+
+    encoding = {'time': {'units': 'days since 0000-01-01'}}
+    ds.to_netcdf(outFileName, encoding=encoding)
+
+
+model = 'UKESM1-0-LL'
+run = 'r1i1p1f2'
+
+dates = {'thetao': ['185001-189912',
+                    '190001-194912',
+                    '195001-199912',
+                    '200001-201412'],
+         'so': ['185001-189912',
+                '190001-194912',
+                '195001-199912',
+                '200001-201412']}
+
+histFiles = {}
+for field in dates:
+    histFiles[field] = []
+    for date in dates[field]:
+        inFileName = '{}/{}_Omon_{}_historical_{}_gn_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        outFileName = '{}/{}_annual_{}_historical_{}_{}.nc'.format(
+            args.out_dir, field, model, run, date)
+
+        compute_yearly_mean(inFileName, outFileName)
+        histFiles[field].append(outFileName)
+
+dates = {'thetao': ['201501-204912'],
+         'so': ['201501-204912']}
+for scenario in ['ssp585']:
+    scenarioFiles = {}
+    for field in dates:
+        scenarioFiles[field] = []
+        for date in dates[field]:
+            inFileName = '{}/{}_Omon_{}_{}_{}_gn_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            outFileName = '{}/{}_annual_{}_{}_{}_{}.nc'.format(
+                args.out_dir, field, model, scenario, run, date)
+
+            compute_yearly_mean(inFileName, outFileName)
+            scenarioFiles[field].append(outFileName)
+
+    for field in ['so', 'thetao']:
+        outFileName = \
+            '{}/{}_annual_{}_{}_{}_185001-201412.nc'.format(
+                args.out_dir, field, model, scenario, run)
+        if not os.path.exists(outFileName):
+            print(outFileName)
+
+            # combine it all into a single data set
+            ds = xarray.open_mfdataset(histFiles[field] + scenarioFiles[field],
+                                       combine='nested', concat_dim='time',
+                                       use_cftime=True)
+
+            mask = ds['time.year'] <= 2014
+            tIndices = numpy.nonzero(mask.values)[0]
+            ds = ds.isel(time=tIndices)
+            encoding = {'time': {'units': 'days since 0000-01-01'}}
+            ds.to_netcdf(outFileName, encoding=encoding)

--- a/ismip6_ocean_forcing/thermal_forcing/main.py
+++ b/ismip6_ocean_forcing/thermal_forcing/main.py
@@ -58,7 +58,7 @@ def compute_thermal_forcing(temperatureFileName, salinityFileName, outFileName,
                                                       0.)
             thermalForcing[tIndex, zIndex, :, :] = thermalForcingLocal
 
-            widgets[0] = '  z={}/{}: '.format(zIndex+1, nz)
+            bar.widgets[0] = '  z={}/{}: '.format(zIndex+1, nz)
             bar.update(tIndex + nt*zIndex)
 
     bar.finish()


### PR DESCRIPTION
This merge adds preprocessing scripts for the remaining models and scenarios needed for generating the Antarctic ocean forcing over the historical period (typically 1850-1994).

Some example templates and setup files are added for setting up runs on a supercomputer, Cori at the DOE NERSC facility.

Some small bug fixes and updates to the examples are included.