### PR TITLE
Fix model/remap.py and woa/main.py

### DIFF
--- a/ismip6_ocean_forcing/model/remap.py
+++ b/ismip6_ocean_forcing/model/remap.py
@@ -246,7 +246,7 @@ def _remap(config, modelFolder):
             '{}/{}_t_*.nc'.format(progressDir, modelName), combine='nested',
             concat_dim='time')
         #Fully load netcdf files.
-        dsOut = dsOut.load()
+        dsOut.load()
 
         dsOut['z_bnds'] = ds.z_bnds
 

--- a/ismip6_ocean_forcing/model/remap.py
+++ b/ismip6_ocean_forcing/model/remap.py
@@ -245,7 +245,11 @@ def _remap(config, modelFolder):
         dsOut = xarray.open_mfdataset(
             '{}/{}_t_*.nc'.format(progressDir, modelName), combine='nested',
             concat_dim='time')
+        #Fully load netcdf files.
+        dsOut = dsOut.load()
 
         dsOut['z_bnds'] = ds.z_bnds
 
         dsOut.to_netcdf(outFileName)
+        #Close xarray object.
+        dsOut.close()

--- a/ismip6_ocean_forcing/woa/main.py
+++ b/ismip6_ocean_forcing/woa/main.py
@@ -25,7 +25,8 @@ def process_woa(config, decades):
             baseURL = 'https://data.nodc.noaa.gov/thredds/fileServer/ncei/' \
                       'woa/{}/{}/0.25/'.format(fieldName, decade)
             fileNames = ['woa18_{}_{}00_04.nc'.format(decade, shortName)]
-            download_files(fileNames, baseURL, 'woa')
+            if not os.path.isfile(os.path.join('woa',fileNames[0])):
+                download_files(fileNames, baseURL, 'woa')
 
     remap.remap_woa(config, woaDecades, woaWeights, decades)
 

--- a/ismip6_ocean_forcing/woa/main.py
+++ b/ismip6_ocean_forcing/woa/main.py
@@ -25,7 +25,7 @@ def process_woa(config, decades):
             baseURL = 'https://data.nodc.noaa.gov/thredds/fileServer/ncei/' \
                       'woa/{}/{}/0.25/'.format(fieldName, decade)
             fileNames = ['woa18_{}_{}00_04.nc'.format(decade, shortName)]
-            if not os.path.isfile(os.path.join('woa',fileNames[0])):
+            if not os.path.exists(os.path.join('woa',fileNames[-1])):
                 download_files(fileNames, baseURL, 'woa')
 
     remap.remap_woa(config, woaDecades, woaWeights, decades)


### PR DESCRIPTION
`model/remap.py`

* Fix bugs reported in https://github.com/ismip/ismip6-antarctic-ocean-forcing/issues/45.
* Ensured full loading of NetCDF files by calling `dsOut.load()` after `dsOut = xarray.open_mfdataset()`, and properly closed the xarray object after saving the remapped dataset.

`woa/main.py`
* Skip WOA data download if the file already exists.